### PR TITLE
feat(cache): add cookie caching for Jackett authentication

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -11,10 +11,12 @@ from app.services.cache import (
     get_configured_indexers_from_cache,
     set_configured_indexers_in_cache,
     get_detailed_configured_indexers_from_cache,
-    set_detailed_configured_indexers_in_cache
+    set_detailed_configured_indexers_in_cache,
+    get_jackett_cookie_from_cache,
+    set_jackett_cookie_in_cache
 )
 from app.services.jackett_client import (
-    get_jackett_cookie,
+    get_jackett_cookie_cached,
     get_configured_indexers,
     get_detailed_configured_indexers,
     stream_jackett_results_for_indexer
@@ -45,6 +47,37 @@ def get_indexer_ids_from_cache():
 
     return None
 
+
+async def ensure_jackett_auth_and_indexers():
+    """
+    Common helper for authentication and indexer fetching/caching.
+    Returns (jackett_cookie, configured_indexers) or raises AuthError with error message.
+    Used by all event generators to avoid duplication.
+    """
+    jackett_cookie = get_jackett_cookie_cached()
+    if not jackett_cookie:
+        raise AuthError(AUTHENTICATION_ERROR)
+
+    configured_indexers = get_indexer_ids_from_cache()
+
+    if not configured_indexers:
+        try:
+            configured_indexers = await get_configured_indexers(jackett_cookie)
+            set_configured_indexers_in_cache(configured_indexers)
+        except HTTPException as e:
+            logger.error(f"Failed to fetch indexers: {e.detail}")
+            raise AuthError(orjson.dumps(e.detail).decode())
+        except Exception as e:
+            logger.error(f"Unexpected error fetching indexers: {str(e)}")
+            raise AuthError(INDEXER_FETCH_ERROR)
+
+    return jackett_cookie, configured_indexers
+
+
+class AuthError(Exception):
+    """Custom exception for authentication/indexer errors in generators"""
+    pass
+
 # Pydantic models
 class MultipleIndexerSearchRequest(BaseModel):
     indexer_ids: List[str]
@@ -64,26 +97,11 @@ app.add_middleware(
 async def event_generator(query: str):
     """Stream individual results from all indexers in parallel as they arrive"""
     try:
-        configured_indexers = get_indexer_ids_from_cache()
-
-        if not configured_indexers:
-            jackett_cookie = get_jackett_cookie()
-            if not jackett_cookie:
-                logger.error("Failed to authenticate with Jackett")
-                yield "event: error\ndata: Failed to authenticate with Jackett\n\n"
-                return
-
-            try:
-                configured_indexers = await get_configured_indexers(jackett_cookie)
-                set_configured_indexers_in_cache(configured_indexers)
-            except HTTPException as e:
-                logger.error(f"Failed to fetch indexers: {e.detail}")
-                yield f"event: error\ndata: {orjson.dumps(e.detail).decode()}\n\n"
-                return
-            except Exception as e:
-                logger.error(f"Unexpected error fetching indexers: {str(e)}")
-                yield "event: error\ndata: Unexpected error occurred while fetching indexers\n\n"
-                return
+        try:
+            jackett_cookie, configured_indexers = await ensure_jackett_auth_and_indexers()
+        except AuthError as e:
+            yield f"event: error\ndata: {e}\n\n"
+            return
 
         # Initialize result deduplicator
         deduplicator = ResultDeduplicator()
@@ -94,7 +112,7 @@ async def event_generator(query: str):
         # Launch all indexers in parallel, each streaming to the queue
         tasks = []
         for indexer_id in configured_indexers:
-            task = asyncio.create_task(stream_jackett_results_for_indexer(indexer_id, query, result_queue))
+            task = asyncio.create_task(stream_jackett_results_for_indexer(indexer_id, query, result_queue, jackett_cookie))
             tasks.append(task)
 
         completed_indexers = set()
@@ -153,27 +171,11 @@ async def event_generator(query: str):
 async def multiple_indexers_event_generator(indexer_ids: List[str], query: str):
     """Stream individual results from specified indexers in parallel as they arrive"""
     try:
-        # Get all configured indexers to validate the requested ones
-        configured_indexers = get_indexer_ids_from_cache()
-
-        if not configured_indexers:
-            jackett_cookie = get_jackett_cookie()
-            if not jackett_cookie:
-                logger.error(AUTHENTICATION_ERROR)
-                yield f"event: error\ndata: {AUTHENTICATION_ERROR}\n\n"
-                return
-
-            try:
-                configured_indexers = await get_configured_indexers(jackett_cookie)
-                set_configured_indexers_in_cache(configured_indexers)
-            except HTTPException as e:
-                logger.error(f"Failed to fetch indexers: {e.detail}")
-                yield f"event: error\ndata: {orjson.dumps(e.detail).decode()}\n\n"
-                return
-            except Exception as e:
-                logger.error(f"Unexpected error fetching indexers: {str(e)}")
-                yield f"event: error\ndata: {INDEXER_FETCH_ERROR}\n\n"
-                return
+        try:
+            jackett_cookie, configured_indexers = await ensure_jackett_auth_and_indexers()
+        except AuthError as e:
+            yield f"event: error\ndata: {e}\n\n"
+            return
 
         # Validate that all requested indexers exist
         invalid_indexers = []
@@ -202,7 +204,7 @@ async def multiple_indexers_event_generator(indexer_ids: List[str], query: str):
         # Launch valid indexers in parallel, each streaming to the queue
         tasks = []
         for indexer_id in valid_indexers:
-            task = asyncio.create_task(stream_jackett_results_for_indexer(indexer_id, query, result_queue))
+            task = asyncio.create_task(stream_jackett_results_for_indexer(indexer_id, query, result_queue, jackett_cookie))
             tasks.append(task)
 
         completed_indexers = set()
@@ -285,7 +287,7 @@ async def get_indexers():
             })
 
         # If not in cache, fetch from Jackett API
-        jackett_cookie = get_jackett_cookie()
+        jackett_cookie = get_jackett_cookie_cached()
         if not jackett_cookie:
             raise HTTPException(status_code=500, detail="Failed to retrieve Jackett cookie")
 
@@ -313,26 +315,11 @@ async def get_indexers():
 async def single_indexer_event_generator(indexer_id: str, query: str):
     """Stream results from a single indexer"""
     try:
-        # Validate indexer exists
-        configured_indexers = get_indexer_ids_from_cache()
-        if not configured_indexers:
-            jackett_cookie = get_jackett_cookie()
-            if not jackett_cookie:
-                logger.error("Failed to authenticate with Jackett")
-                yield "event: error\ndata: Failed to authenticate with Jackett\n\n"
-                return
-
-            try:
-                configured_indexers = await get_configured_indexers(jackett_cookie)
-                set_configured_indexers_in_cache(configured_indexers)
-            except HTTPException as e:
-                logger.error(f"Failed to fetch indexers: {e.detail}")
-                yield f"event: error\ndata: {orjson.dumps(e.detail).decode()}\n\n"
-                return
-            except Exception as e:
-                logger.error(f"Unexpected error fetching indexers: {str(e)}")
-                yield "event: error\ndata: Unexpected error occurred while fetching indexers\n\n"
-                return
+        try:
+            jackett_cookie, configured_indexers = await ensure_jackett_auth_and_indexers()
+        except AuthError as e:
+            yield f"event: error\ndata: {e}\n\n"
+            return
 
         if indexer_id not in configured_indexers:
             logger.error(f"Indexer not found: {indexer_id}")
@@ -343,7 +330,7 @@ async def single_indexer_event_generator(indexer_id: str, query: str):
         result_queue = asyncio.Queue()
 
         # Launch the single indexer task
-        task = asyncio.create_task(stream_jackett_results_for_indexer(indexer_id, query, result_queue))
+        task = asyncio.create_task(stream_jackett_results_for_indexer(indexer_id, query, result_queue, jackett_cookie))
 
         results_streamed = 0
         indexer_completed = False

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -8,7 +8,12 @@ logger = logging.getLogger(__name__)
 CACHE_DIR = "./cache_dir"
 CACHE_KEY = "configured_indexers"
 CACHE_KEY_DETAILED = "configured_indexers_detailed"
+CACHE_KEY_COOKIE = "jackett_cookie"
 CACHE_DURATION = 86400  # seconds (24 hours)
+CACHE_COOKIE_DURATION = 1209600  # seconds (14 days)
+
+# In-memory cache for cookie to work with multiprocessing
+_memory_cache = {}
 
 # Ensure cache directory exists
 try:
@@ -121,3 +126,30 @@ def set_detailed_configured_indexers_in_cache(indexers: List[Dict[str, str]]) ->
     except Exception as e:
         logger.error(f"Error writing detailed indexers to cache: {str(e)}")
         return False
+
+
+def get_jackett_cookie_from_cache() -> Optional[str]:
+    """
+    Loads Jackett cookie from in-memory cache.
+    Returns None if not found.
+    """
+    result = _memory_cache.get(CACHE_KEY_COOKIE)
+    if result and isinstance(result, str):
+        logger.info("Retrieved Jackett cookie from in-memory cache")
+        return result
+    logger.info("No cached cookie found in memory")
+    return None
+
+
+def set_jackett_cookie_in_cache(cookie: str) -> bool:
+    """
+    Saves Jackett cookie to in-memory cache.
+    Returns True if successful, False otherwise.
+    """
+    if not isinstance(cookie, str):
+        logger.error("Invalid cookie data type for cache")
+        return False
+
+    _memory_cache[CACHE_KEY_COOKIE] = cookie
+    logger.info("Successfully cached Jackett cookie in memory")
+    return True

--- a/app/services/jackett_client.py
+++ b/app/services/jackett_client.py
@@ -3,6 +3,10 @@ from typing import Any, Optional, Dict, List
 from fastapi import HTTPException
 import logging
 from pydantic_settings import BaseSettings
+from app.services.cache import (
+    get_jackett_cookie_from_cache,
+    set_jackett_cookie_in_cache
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -26,31 +30,44 @@ JACKETT_API_URL = settings.JACKETT_API_URL
 API_KEY = settings.API_KEY
 
 
-async def get_configured_indexers(jackett_cookie: str) -> list[str]:
+async def fetch_indexers_data(jackett_cookie: str) -> List[Dict]:
+    """
+    Fetch raw indexer data from Jackett API.
+    Common function used by get_configured_indexers and get_detailed_configured_indexers.
+    """
     if not jackett_cookie or not jackett_cookie.strip():
         raise HTTPException(status_code=400, detail="Jackett cookie is required")
 
     params = {"apikey": API_KEY, "configured": 'true'}
-    headers = {'Cookie': f'Jackett={jackett_cookie.strip()}'}
+    headers = {
+        'Cookie': f'Jackett={jackett_cookie.strip()}',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+        'Accept': 'application/json, text/plain, */*',
+        'Accept-Language': 'en-US,en;q=0.9'
+    }
     url = f"{JACKETT_API_URL}/api/v2.0/indexers"
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(url, params=params, headers=headers)
+
+            # Check for redirect responses
+            if response.is_redirect:
+                logger.warning(f"Redirect detected when fetching indexers: {response.status_code}")
+                # Follow the redirect manually
+                redirect_url = response.headers.get('Location')
+                if redirect_url:
+                    logger.info(f"Following redirect to: {redirect_url}")
+                    response = await client.get(redirect_url, params=params, headers=headers)
+
+            # Ensure we have a successful response
+            response.raise_for_status()
 
             indexers_data = response.json()
             if not isinstance(indexers_data, list):
                 raise HTTPException(status_code=500, detail=INVALID_RESPONSE_FORMAT)
 
-            configured_indexers = [
-                indexer["id"] for indexer in indexers_data
-                if isinstance(indexer, dict) and indexer.get("configured", False) and indexer.get("id")
-            ]
-
-            if not configured_indexers:
-                logger.warning(NO_CONFIGURED_INDEXERS)
-
-            return configured_indexers
+            return indexers_data
 
     except httpx.HTTPStatusError as e:
         error_message = f"Jackett API HTTP error: {e.response.status_code}"
@@ -70,61 +87,38 @@ async def get_configured_indexers(jackett_cookie: str) -> list[str]:
         raise HTTPException(status_code=500, detail=error_message)
 
 
+async def get_configured_indexers(jackett_cookie: str) -> list[str]:
+    indexers_data = await fetch_indexers_data(jackett_cookie)
+    configured_indexers = [
+        indexer["id"] for indexer in indexers_data
+        if isinstance(indexer, dict) and indexer.get("configured", False) and indexer.get("id")
+    ]
+    if not configured_indexers:
+        logger.warning(NO_CONFIGURED_INDEXERS)
+    return configured_indexers
+
+
 async def get_detailed_configured_indexers(jackett_cookie: str) -> List[Dict[str, str]]:
     """
     Get detailed information about configured indexers including id and site_link.
     Returns a list of dictionaries with 'id' and 'site_link' fields.
     """
-    if not jackett_cookie or not jackett_cookie.strip():
-        raise HTTPException(status_code=400, detail="Jackett cookie is required")
-
-    params = {"apikey": API_KEY, "configured": 'true'}
-    headers = {'Cookie': f'Jackett={jackett_cookie.strip()}'}
-    url = f"{JACKETT_API_URL}/api/v2.0/indexers"
-
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url, params=params, headers=headers)
-
-            indexers_data = response.json()
-            if not isinstance(indexers_data, list):
-                raise HTTPException(status_code=500, detail=INVALID_RESPONSE_FORMAT)
-
-            detailed_indexers = []
-            for indexer in indexers_data:
-                if (isinstance(indexer, dict) and
-                    indexer.get("configured", False) and
-                    indexer.get("id")):
-
-                    detailed_indexers.append({
-                        "id": indexer["id"],
-                        "site_link": indexer.get("site_link", "")
-                    })
-
-            if not detailed_indexers:
-                logger.warning(NO_CONFIGURED_INDEXERS)
-
-            return detailed_indexers
-
-    except httpx.HTTPStatusError as e:
-        error_message = f"Jackett API HTTP error: {e.response.status_code}"
-        logger.error(error_message)
-        raise HTTPException(status_code=e.response.status_code, detail=error_message)
-    except httpx.TimeoutException:
-        error_message = "Timeout connecting to Jackett API"
-        logger.error(error_message)
-        raise HTTPException(status_code=504, detail=error_message)
-    except httpx.HTTPError as e:
-        error_message = f"Error connecting to Jackett API: {str(e)}"
-        logger.error(error_message)
-        raise HTTPException(status_code=500, detail=error_message)
-    except Exception as e:
-        error_message = f"Unexpected error fetching detailed indexers: {str(e)}"
-        logger.error(error_message)
-        raise HTTPException(status_code=500, detail=error_message)
+    indexers_data = await fetch_indexers_data(jackett_cookie)
+    detailed_indexers = []
+    for indexer in indexers_data:
+        if (isinstance(indexer, dict) and
+            indexer.get("configured", False) and
+            indexer.get("id")):
+            detailed_indexers.append({
+                "id": indexer["id"],
+                "site_link": indexer.get("site_link", "")
+            })
+    if not detailed_indexers:
+        logger.warning(NO_CONFIGURED_INDEXERS)
+    return detailed_indexers
 
 
-async def fetch_jackett_results_for_indexer(indexer_id: str, query: str):
+async def fetch_jackett_results_for_indexer(indexer_id: str, query: str, jackett_cookie: str):
     """
     Fetch results from a single indexer.
     Returns a list of results or empty list on error.
@@ -137,12 +131,22 @@ async def fetch_jackett_results_for_indexer(indexer_id: str, query: str):
         logger.error("Invalid query provided")
         return []
 
+    if not jackett_cookie or not jackett_cookie.strip():
+        logger.error("Invalid jackett_cookie provided")
+        return []
+
     url = f"{JACKETT_API_URL}/api/v2.0/indexers/{indexer_id.strip()}/results"
     params = {"apikey": API_KEY, "Query": query.strip()}
+    headers = {
+        'Cookie': f'Jackett={jackett_cookie.strip()}',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+        'Accept': 'application/json, text/plain, */*',
+        'Accept-Language': 'en-US,en;q=0.9'
+    }
 
     try:
         async with httpx.AsyncClient(timeout=60) as client:
-            response = await client.get(url, params=params)
+            response = await client.get(url, params=params, headers=headers)
             response.raise_for_status()
             data = response.json()
 
@@ -167,7 +171,7 @@ async def fetch_jackett_results_for_indexer(indexer_id: str, query: str):
         logger.error(f"Unexpected error fetching from indexer {indexer_id}: {str(e)}")
         return []
 
-async def stream_jackett_results_for_indexer(indexer_id: str, query: str, result_queue):
+async def stream_jackett_results_for_indexer(indexer_id: str, query: str, result_queue, jackett_cookie: str):
     """
     Fetch results from a single indexer and put them in the queue as they arrive.
     This allows for immediate streaming of individual results.
@@ -180,12 +184,22 @@ async def stream_jackett_results_for_indexer(indexer_id: str, query: str, result
         logger.error("Invalid query provided")
         return
 
+    if not jackett_cookie or not jackett_cookie.strip():
+        logger.error("Invalid jackett_cookie provided")
+        return
+
     url = f"{JACKETT_API_URL}/api/v2.0/indexers/{indexer_id.strip()}/results"
     params = {"apikey": API_KEY, "Query": query.strip()}
+    headers = {
+        'Cookie': f'Jackett={jackett_cookie.strip()}',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+        'Accept': 'application/json, text/plain, */*',
+        'Accept-Language': 'en-US,en;q=0.9'
+    }
 
     try:
         async with httpx.AsyncClient(timeout=60) as client:
-            response = await client.get(url, params=params)
+            response = await client.get(url, params=params, headers=headers)
             response.raise_for_status()
             data = response.json()
 
@@ -229,6 +243,32 @@ async def stream_jackett_results_for_indexer(indexer_id: str, query: str, result
             })
         except Exception as queue_error:
             logger.error(f"Failed to put error in queue for {indexer_id}: {str(queue_error)}")
+
+def get_jackett_cookie_cached() -> Optional[str]:
+    """
+    Retrieves the 'Jackett' cookie from cache first, and if not available,
+    fetches it using the authentication flow and caches it for future use.
+    
+    The cookie is cached for 14 days to match Jackett's cookie expiry period.
+    
+    Returns:
+      The value of the 'Jackett' cookie, or None if the login fails or the cookie is not found.
+    """
+    # Try to get cached cookie first
+    cached_cookie = get_jackett_cookie_from_cache()
+    if cached_cookie:
+        logger.info("Using cached Jackett cookie")
+        return cached_cookie
+    
+    # If not in cache, fetch a new one
+    logger.info("No cached cookie found, fetching new Jackett cookie")
+    cookie = get_jackett_cookie()
+    if cookie:
+        # Cache the newly fetched cookie
+        set_jackett_cookie_in_cache(cookie)
+    
+    return cookie
+
 
 def get_jackett_cookie() -> Optional[str]:
     """


### PR DESCRIPTION
Introduce in-memory caching for Jackett cookies to persist across requests and reduce redundant authentication calls. Refactor event generators to use a common `ensure_jackett_auth_and_indexers` helper function, eliminating code duplication. Enhance HTTP requests with user-agent headers and redirect handling for better compatibility.